### PR TITLE
Matlab R2014a or later support

### DIFF
--- a/BINGMultiple.cpp
+++ b/BINGMultiple.cpp
@@ -36,7 +36,20 @@ using namespace std;
 #define _NSS  2
 #define _NUM_PER_SZ 130
 
-extern "C" mxArray* mxCreateReference(mxArray*);
+struct mxArray_Tag_Partial {
+    void *name_or_CrossLinkReverse;
+    mxClassID ClassID;
+    int VariableType;
+    mxArray *CrossLink;
+    size_t ndim;
+    unsigned int RefCount;
+};
+mxArray *mxCreateReference(const mxArray *mx)
+{
+    struct mxArray_Tag_Partial *my = (struct mxArray_Tag_Partial *) mx;
+    ++my->RefCount;
+    return (mxArray *) mx;
+}
 
 void mexFunction( int nlhs, mxArray* plhs[], int nrhs, const mxArray* prhs[] )
 {

--- a/Objectness/Src/Objectness.cpp
+++ b/Objectness/Src/Objectness.cpp
@@ -790,7 +790,7 @@ void Objectness::getObjBndBoxesForTest( cv::Mat im, vector<Vec4i> &_boxes, int n
   getObjBndBoxes(im, boxesTests, numDetPerSize);
 
   _boxes.resize(boxesTests.size());
-  for (int j = 0; j < boxesTests.size(); j++)
+  for (int j = 0; j < 4 * boxesTests.size(); j++)
     _boxes[0][j] = boxesTests[0][j];
 }
 


### PR DESCRIPTION
Maybe someone will use.

Since R2014a, mxCreateReference is no longer available. So one will see the `undefined reference to mxCreateReference` error when recompiling this project. To fix this, the `mxCreateReference` function can be completed as follows:

```
struct mxArray_Tag_Partial {
    void *name_or_CrossLinkReverse;
    mxClassID ClassID;
    int VariableType;
    mxArray *CrossLink;
    size_t ndim;
    unsigned int RefCount;
};
mxArray *mxCreateReference(const mxArray *mx)
{
    struct mxArray_Tag_Partial *my = (struct mxArray_Tag_Partial *) mx;
    ++my->RefCount;
    return (mxArray *) mx;
}
```

reference: https://stackoverflow.com/a/28977840/3547675